### PR TITLE
Support rp in writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 3.0.2 
+ * Added support for RP in write operations. Issue #9.
 
 ## 3.0.1
  * Fixed issue #7

--- a/src/Vibrant.InfluxDB.Client/InfluxClient.cs
+++ b/src/Vibrant.InfluxDB.Client/InfluxClient.cs
@@ -847,7 +847,9 @@ namespace Vibrant.InfluxDB.Client
       }
       private string CreateWriteUrl( string db, InfluxWriteOptions options )
       {
-         return $"write?db={Uri.EscapeDataString( db )}&precision={options.Precision.GetQueryParameter()}&consistency={options.Consistency.GetQueryParameter()}";
+         var url = $"write?db={Uri.EscapeDataString( db )}&precision={options.Precision.GetQueryParameter()}&consistency={options.Consistency.GetQueryParameter()}";
+         if (!string.IsNullOrEmpty(options.RetentionPolicy)) url += $"&rp={options.RetentionPolicy}";
+         return url;
       }
 
       private string CreateQueryUrl( string commandOrQuery, string db, InfluxQueryOptions options )

--- a/src/Vibrant.InfluxDB.Client/InfluxWriteOptions.cs
+++ b/src/Vibrant.InfluxDB.Client/InfluxWriteOptions.cs
@@ -29,5 +29,10 @@ namespace Vibrant.InfluxDB.Client
       /// Gets or sets the precision. Default is nanosecond.
       /// </summary>
       public TimestampPrecision Precision { get; set; }
+
+      /// <summary>
+      /// Gets or sets the retention policy to write. If omitted (null, default), writes go to database's default RP.
+      /// </summary>
+      public string RetentionPolicy { get; set; } 
    }
 }

--- a/src/Vibrant.InfluxDB.Client/project.json
+++ b/src/Vibrant.InfluxDB.Client/project.json
@@ -1,5 +1,5 @@
 ﻿{
-   "version": "3.0.1-*",
+   "version": "3.0.2-*",
    "title": "InfluxDB Client for .NET",
    "description": "An easy-to-use client for InfluxDB that supports simple query to object mapping.",
    "authors": [ "MikaelGRA" ],

--- a/test/Vibrant.InfluxDB.Client.Tests/RetentionPolicyTests.cs
+++ b/test/Vibrant.InfluxDB.Client.Tests/RetentionPolicyTests.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Vibrant.InfluxDB.Client.Tests
+{
+    [Collection("InfluxClient collection")]
+    public class RetentionPolicyTests
+    {
+        private const string RpName = "mypolicy";
+        private const string MeasurementName = "computer_infos_rp";
+
+        private InfluxClient _client;
+
+        public RetentionPolicyTests(InfluxClientFixture fixture)
+        {
+            _client = fixture.Client;
+        }
+
+        [Fact]
+        public async Task Should_Write_And_Read_Data_From_Non_Default_RP()
+        {
+
+            _client.CreateRetentionPolicyAsync(InfluxClientFixture.DatabaseName, RpName, "1h", 1, false).Wait();
+            var rps = await _client.ShowRetentionPoliciesAsync(InfluxClientFixture.DatabaseName);
+
+            Assert.True(rps.Succeeded);
+            Assert.Equal(1, rps.Series.Count);
+
+            var rpSeries = rps.Series[0];
+            Assert.Equal(2, rpSeries.Rows.Count);
+
+            var policy = rpSeries.Rows.FirstOrDefault(row => row.Name == RpName);
+            Assert.NotNull(policy);
+            Assert.Equal("1h0m0s", policy.Duration);
+            
+
+
+
+            var infos = InfluxClientFixture.CreateTypedRowsStartingAt(DateTime.Now.AddHours(-2), 2*60*60, false);
+
+            var options = new InfluxWriteOptions
+            {
+                RetentionPolicy = RpName
+            };
+
+            _client.WriteAsync(InfluxClientFixture.DatabaseName, MeasurementName, infos, options).Wait();
+            
+
+            var resultSet = await _client.ReadAsync<ComputerInfo>(InfluxClientFixture.DatabaseName, $"SELECT * FROM {RpName}.{MeasurementName}");
+            Assert.Equal(1, resultSet.Results.Count);
+
+            var result = resultSet.Results[0];
+            Assert.Equal(1, result.Series.Count);
+
+            var series = result.Series[0];
+            Assert.Equal(2*60*60, series.Rows.Count);
+        }
+    }
+}


### PR DESCRIPTION
Implement very simple addition to existing functionality. Adding ?rp=mypolicy to write urls makes it possible to write straight into non-default RP. Our project has this requirement. There's also a test that creates the RP, writes data to it and reads it back. The test doesn't assert the actual functionality of RP. It would require altering the default 30min RP enforcement value and doesn't really make sense in a unit test.