### PR TITLE
Added support for existing DTOs...

### DIFF
--- a/Vibrant.InfluxDB.Client.sln
+++ b/Vibrant.InfluxDB.Client.sln
@@ -17,7 +17,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Vibrant.InfluxDB.Client.Con
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{F02BF63C-126E-461F-8120-036E88E94111}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Vibrant.InfluxDB.Client.SimpleSample", "samples\Vibrant.InfluxDB.Client.SimpleSample\Vibrant.InfluxDB.Client.SimpleSample.csproj", "{361E4B1B-F56C-4F9D-864F-B282177A0740}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Vibrant.InfluxDB.Client.SimpleSample", "samples\Vibrant.InfluxDB.Client.SimpleSample\Vibrant.InfluxDB.Client.SimpleSample.csproj", "{361E4B1B-F56C-4F9D-864F-B282177A0740}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/Vibrant.InfluxDB.Client/DateTimeExtensions.cs
+++ b/src/Vibrant.InfluxDB.Client/DateTimeExtensions.cs
@@ -151,7 +151,7 @@ namespace Vibrant.InfluxDB.Client
                   sb.Append( w ).Append( "w" );
                   if( hasDigits && requireSingleUnit )
                   {
-                     throw new NotSupportedException( "The specfied timespan must resolve to a single full unit (week, day, minute, second and microsecond)." );
+                     throw new NotSupportedException( "The specified timespan must resolve to a single full unit (week, day, minute, second and microsecond)." );
                   }
                   hasDigits = true;
                }
@@ -164,7 +164,7 @@ namespace Vibrant.InfluxDB.Client
                sb.Append( d ).Append( "d" );
                if( hasDigits && requireSingleUnit )
                {
-                  throw new NotSupportedException( "The specfied timespan must resolve to a single full unit (week, day, minute, second and microsecond)." );
+                  throw new NotSupportedException( "The specified timespan must resolve to a single full unit (week, day, minute, second and microsecond)." );
                }
                hasDigits = true;
             }
@@ -176,7 +176,7 @@ namespace Vibrant.InfluxDB.Client
             sb.Append( h ).Append( "h" );
             if( hasDigits && requireSingleUnit )
             {
-               throw new NotSupportedException( "The specfied timespan must resolve to a single full unit (week, day, minute, second and microsecond)." );
+               throw new NotSupportedException( "The specified timespan must resolve to a single full unit (week, day, minute, second and microsecond)." );
             }
             hasDigits = true;
          }
@@ -187,7 +187,7 @@ namespace Vibrant.InfluxDB.Client
             sb.Append( m ).Append( "m" );
             if( hasDigits && requireSingleUnit )
             {
-               throw new NotSupportedException( "The specfied timespan must resolve to a single full unit (week, day, minute, second and microsecond)." );
+               throw new NotSupportedException( "The specified timespan must resolve to a single full unit (week, day, minute, second and microsecond)." );
             }
             hasDigits = true;
          }
@@ -198,7 +198,7 @@ namespace Vibrant.InfluxDB.Client
             sb.Append( s ).Append( "s" );
             if( hasDigits && requireSingleUnit )
             {
-               throw new NotSupportedException( "The specfied timespan must resolve to a single full unit (week, day, minute, second and microsecond)." );
+               throw new NotSupportedException( "The specified timespan must resolve to a single full unit (week, day, minute, second and microsecond)." );
             }
             hasDigits = true;
          }
@@ -209,7 +209,7 @@ namespace Vibrant.InfluxDB.Client
             sb.Append( u ).Append( "u" );
             if( hasDigits && requireSingleUnit )
             {
-               throw new NotSupportedException( "The specfied timespan must resolve to a single full unit (week, day, minute, second and microsecond)." );
+               throw new NotSupportedException( "The specified timespan must resolve to a single full unit (week, day, minute, second and microsecond)." );
             }
             hasDigits = true;
          }

--- a/src/Vibrant.InfluxDB.Client/Http/InfluxRowContent.cs
+++ b/src/Vibrant.InfluxDB.Client/Http/InfluxRowContent.cs
@@ -1,13 +1,11 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
-using System.Net.Sockets;
 using System.Text;
 using System.Threading.Tasks;
 using Vibrant.InfluxDB.Client.Metadata;
@@ -65,7 +63,7 @@ namespace Vibrant.InfluxDB.Client.Http
                   }
                }
 
-               // write tag to field seperator
+               // write tag to field separator
                writer.Write( ' ' );
 
                // write all fields
@@ -149,7 +147,22 @@ namespace Vibrant.InfluxDB.Client.Http
                   }
                }
 
-               // write tag to fields seperator
+                if (_options.DefaultTags.Count > 0)
+                {
+                    foreach (var tag in _options.DefaultTags.OrderBy(x => x.Key, StringComparer.Ordinal))
+                    {
+                        var value = tag.Value;
+                        if (value != null)
+                        {
+                            writer.Write(',');
+                            writer.Write(LineProtocolEscape.EscapeKey(tag.Key));
+                            writer.Write('=');
+                            writer.Write(LineProtocolEscape.EscapeTagValue(value));
+                        }
+                    }
+                }
+
+               // write tag to fields separator
                writer.Write( ' ' );
 
                // write all fields

--- a/src/Vibrant.InfluxDB.Client/InfluxClient.cs
+++ b/src/Vibrant.InfluxDB.Client/InfluxClient.cs
@@ -109,7 +109,7 @@ namespace Vibrant.InfluxDB.Client
       public InfluxWriteOptions DefaultWriteOptions { get; private set; }
 
       /// <summary>
-      /// Gets the default query optionns.
+      /// Gets the default query options.
       /// </summary>
       public InfluxQueryOptions DefaultQueryOptions { get; private set; }
 

--- a/src/Vibrant.InfluxDB.Client/InfluxWriteOptions.cs
+++ b/src/Vibrant.InfluxDB.Client/InfluxWriteOptions.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 
 namespace Vibrant.InfluxDB.Client
 {
@@ -19,6 +15,7 @@ namespace Vibrant.InfluxDB.Client
          Consistency = Consistency.All;
          Precision = TimestampPrecision.Nanosecond;
          UseGzip = false;
+         DefaultTags = new Dictionary<string, string>();
       }
 
       /// <summary>
@@ -40,5 +37,7 @@ namespace Vibrant.InfluxDB.Client
       /// Gets or sets a bool indicating if gzip compression should be used for write operations.
       /// </summary>
       public bool UseGzip { get; set; }
+
+      public Dictionary<string, string> DefaultTags;
    }
 }

--- a/src/Vibrant.InfluxDB.Client/Metadata/MetadataCache.cs
+++ b/src/Vibrant.InfluxDB.Client/Metadata/MetadataCache.cs
@@ -1,9 +1,10 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
 using System.Linq;
 using System.Reflection;
-using System.Threading.Tasks;
 using Vibrant.InfluxDB.Client.Resources;
 using Vibrant.InfluxDB.Client.Rows;
 
@@ -11,33 +12,33 @@ namespace Vibrant.InfluxDB.Client.Metadata
 {
    internal static class MetadataCache
    {
-      private static readonly MethodInfo GetOrCreateMethod = typeof( MetadataCache ).GetMethods( BindingFlags.NonPublic | BindingFlags.Static ).Where( x => x.Name == "GetOrCreate" && x.ContainsGenericParameters ).Single();
+      private static readonly MethodInfo GetOrCreateMethod = typeof(MetadataCache).GetMethods(BindingFlags.NonPublic | BindingFlags.Static).Single(x => x.Name == "GetOrCreate" && x.ContainsGenericParameters);
 
       private static readonly object Sync = new object();
       private static readonly Dictionary<Type, InfluxRowTypeInfo> TypeCache = new Dictionary<Type, InfluxRowTypeInfo>();
-      private static readonly HashSet<Type> ValidFieldTypes = new HashSet<Type> { typeof( string ), typeof( double ), typeof( float ), typeof( long ), typeof( int ), typeof( short ), typeof( byte ), typeof( ulong ), typeof( uint ), typeof( ushort ), typeof( sbyte ), typeof( bool ), typeof( DateTime ) };
+      private static readonly HashSet<Type> ValidFieldTypes = new HashSet<Type> { typeof(string), typeof(double), typeof(float), typeof(long), typeof(int), typeof(short), typeof(byte), typeof(ulong), typeof(uint), typeof(ushort), typeof(sbyte), typeof(bool), typeof(DateTime) };
       private static readonly ConcurrentDictionary<Type, Type> TypeDefinitionMap = new ConcurrentDictionary<Type, Type>();
-      
-      internal static Type GetGenericTypeDefinitionForImplementedInfluxInterface( Type type )
+
+      internal static Type GetGenericTypeDefinitionForImplementedInfluxInterface(Type type)
       {
          Type foundTypeGenericTypeDefinition = null;
 
-         if( !TypeDefinitionMap.TryGetValue( type, out foundTypeGenericTypeDefinition ) )
+         if (!TypeDefinitionMap.TryGetValue(type, out foundTypeGenericTypeDefinition))
          {
-            foreach( var i in type.GetInterfaces() )
+            foreach (var i in type.GetInterfaces())
             {
-               if( i.GetTypeInfo().IsGenericType && i.GetGenericTypeDefinition() == typeof( IInfluxRow<> ) )
+               if (i.GetTypeInfo().IsGenericType && i.GetGenericTypeDefinition() == typeof(IInfluxRow<>))
                {
-                  if( foundTypeGenericTypeDefinition != null )
+                  if (foundTypeGenericTypeDefinition != null)
                   {
-                     throw new InfluxException( string.Format( Errors.MultiInterfaceImplementations, type.FullName ) );
+                     throw new InfluxException(string.Format(Errors.MultiInterfaceImplementations, type.FullName));
                   }
 
                   foundTypeGenericTypeDefinition = i;
                }
             }
 
-            TypeDefinitionMap[ type ] = foundTypeGenericTypeDefinition;
+            TypeDefinitionMap[type] = foundTypeGenericTypeDefinition;
          }
 
          return foundTypeGenericTypeDefinition;
@@ -45,16 +46,16 @@ namespace Vibrant.InfluxDB.Client.Metadata
 
       internal static Type GetGenericTypeDefinitionForImplementedInfluxInterface<TInfluxRow>()
       {
-         return GetGenericTypeDefinitionForImplementedInfluxInterface( typeof( TInfluxRow ) );
+         return GetGenericTypeDefinitionForImplementedInfluxInterface(typeof(TInfluxRow));
       }
 
-      internal static InfluxRowTypeInfo GetOrCreate( Type type )
+      internal static InfluxRowTypeInfo GetOrCreate(Type type)
       {
-         lock( Sync )
+         lock (Sync)
          {
-            if( !TypeCache.TryGetValue( type, out InfluxRowTypeInfo cache ) )
+            if (!TypeCache.TryGetValue(type, out InfluxRowTypeInfo cache))
             {
-               return (InfluxRowTypeInfo)GetOrCreateMethod.MakeGenericMethod( new[] { type } ).Invoke( null, null );
+               return (InfluxRowTypeInfo) GetOrCreateMethod.MakeGenericMethod(new[] { type }).Invoke(null, null);
             }
 
             return cache;
@@ -64,23 +65,24 @@ namespace Vibrant.InfluxDB.Client.Metadata
       internal static InfluxRowTypeInfo<TInfluxRow> GetOrCreate<TInfluxRow>()
          where TInfluxRow : new()
       {
-         lock( Sync )
+         lock (Sync)
          {
             InfluxRowTypeInfo cache;
-            var type = typeof( TInfluxRow );
+            var type = typeof(TInfluxRow);
 
-            if( !TypeCache.TryGetValue( type, out cache ) )
+            if (!TypeCache.TryGetValue(type, out cache))
             {
                Type timestampType = null;
 
                var computed = new List<PropertyExpressionInfo<TInfluxRow>>();
                var tags = new List<PropertyExpressionInfo<TInfluxRow>>();
                var fields = new List<PropertyExpressionInfo<TInfluxRow>>();
+
                var all = new List<PropertyExpressionInfo<TInfluxRow>>();
                PropertyExpressionInfo<TInfluxRow> timestamp = null;
                PropertyExpressionInfo<TInfluxRow> influxMeasurement = null;
 
-               foreach( var propertyInfo in type.GetProperties( BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public ) )
+               foreach (var propertyInfo in type.GetProperties(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public))
                {
                   var fieldAttribute = propertyInfo.GetCustomAttribute<InfluxFieldAttribute>();
                   var tagAttribute = propertyInfo.GetCustomAttribute<InfluxTagAttribute>();
@@ -88,102 +90,121 @@ namespace Vibrant.InfluxDB.Client.Metadata
                   var timestampAttribute = propertyInfo.GetCustomAttribute<InfluxTimestampAttribute>();
                   var influxMeasurementAttribute = propertyInfo.GetCustomAttribute<InfluxMeasurementAttribute>();
 
-                  // list all attributes so we can ensure the attributes specified on a property are valid
-                  var allAttributes = new Attribute[] { fieldAttribute, tagAttribute, timestampAttribute, computedAttribute }
-                     .Where( x => x != null )
-                     .ToList();
+                  var notMappedAttribute = propertyInfo.GetCustomAttribute<NotMappedAttribute>();
+                  var columnAttribute = propertyInfo.GetCustomAttribute<ColumnAttribute>();
+                  var keyAttribute = propertyInfo.GetCustomAttribute<KeyAttribute>();
 
-                  if( allAttributes.Count > 1 )
+                  // list all attributes so we can ensure the attributes specified on a property are valid
+                  var allAttributes = new Attribute[] { fieldAttribute, tagAttribute, timestampAttribute, computedAttribute, notMappedAttribute, columnAttribute, keyAttribute }
+                   .Where(x => x != null)
+                   .ToList();
+
+                  if (allAttributes.Count > 1)
                   {
-                     throw new InfluxException( string.Format( Errors.MultipleAttributesOnSingleProperty, propertyInfo.Name, type.Name ) );
+                     throw new InfluxException(string.Format(Errors.MultipleAttributesOnSingleProperty, propertyInfo.Name, type.Name));
                   }
 
-                  if( timestampAttribute != null )
+                  if (timestampAttribute != null || keyAttribute != null)
                   {
-                     timestamp = new PropertyExpressionInfo<TInfluxRow>( InfluxConstants.TimeColumn, propertyInfo );
+                     timestamp = new PropertyExpressionInfo<TInfluxRow>(InfluxConstants.TimeColumn, propertyInfo);
 
-                     all.Add( timestamp );
+                     all.Add(timestamp);
                      timestampType = timestamp.RawType;
                   }
-                  else if( fieldAttribute != null )
+                  else if (tagAttribute != null)
                   {
-                     var expression = new PropertyExpressionInfo<TInfluxRow>( fieldAttribute.Name, propertyInfo );
-                     if( !ValidFieldTypes.Contains( expression.Type ) && !expression.Type.GetTypeInfo().IsEnum )
+                     var expression = new PropertyExpressionInfo<TInfluxRow>(tagAttribute.Name, propertyInfo);
+                     if (!ValidFieldTypes.Contains(expression.Type) && !expression.Type.GetTypeInfo().IsEnum)
                      {
-                        throw new InfluxException( string.Format( Errors.InvalidFieldType, propertyInfo.Name, type.Name ) );
+                        throw new InfluxException(string.Format(Errors.InvalidTagType, propertyInfo.Name, type.Name));
                      }
 
-                     if( string.IsNullOrEmpty( fieldAttribute.Name ) )
+                     if (string.IsNullOrEmpty(tagAttribute.Name))
                      {
-                        throw new InfluxException( string.Format( Errors.InvalidNameProperty, propertyInfo.Name, type.Name ) );
+                        throw new InfluxException(string.Format(Errors.InvalidNameProperty, propertyInfo.Name, type.Name));
                      }
 
-                     fields.Add( expression );
-                     all.Add( expression );
+                     tags.Add(expression);
+                     all.Add(expression);
                   }
-                  else if( tagAttribute != null )
+                  else if (computedAttribute != null)
                   {
-                     var expression = new PropertyExpressionInfo<TInfluxRow>( tagAttribute.Name, propertyInfo );
-                     if( !ValidFieldTypes.Contains( expression.Type ) && !expression.Type.GetTypeInfo().IsEnum )
+                     var expression = new PropertyExpressionInfo<TInfluxRow>(computedAttribute.Name, propertyInfo);
+                     if (!ValidFieldTypes.Contains(expression.Type) && !expression.Type.GetTypeInfo().IsEnum)
                      {
-                        throw new InfluxException( string.Format( Errors.InvalidTagType, propertyInfo.Name, type.Name ) );
+                        throw new InfluxException(string.Format(Errors.InvalidComputedType, propertyInfo.Name, type.Name));
                      }
 
-                     if( string.IsNullOrEmpty( tagAttribute.Name ) )
+                     if (string.IsNullOrEmpty(computedAttribute.Name))
                      {
-                        throw new InfluxException( string.Format( Errors.InvalidNameProperty, propertyInfo.Name, type.Name ) );
+                        throw new InfluxException(string.Format(Errors.InvalidNameProperty, propertyInfo.Name, type.Name));
                      }
 
-                     tags.Add( expression );
-                     all.Add( expression );
+                     computed.Add(expression);
+                     all.Add(expression);
                   }
-                  else if( computedAttribute != null )
+                  else if (influxMeasurementAttribute != null)
                   {
-                     var expression = new PropertyExpressionInfo<TInfluxRow>( computedAttribute.Name, propertyInfo );
-                     if( !ValidFieldTypes.Contains( expression.Type ) && !expression.Type.GetTypeInfo().IsEnum )
+                     var expression = new PropertyExpressionInfo<TInfluxRow>(null, propertyInfo);
+                     if (expression.Type != typeof(string))
                      {
-                        throw new InfluxException( string.Format( Errors.InvalidComputedType, propertyInfo.Name, type.Name ) );
-                     }
-
-                     if( string.IsNullOrEmpty( computedAttribute.Name ) )
-                     {
-                        throw new InfluxException( string.Format( Errors.InvalidNameProperty, propertyInfo.Name, type.Name ) );
-                     }
-
-                     computed.Add( expression );
-                     all.Add( expression );
-                  }
-                  else if( influxMeasurementAttribute != null )
-                  {
-                     var expression = new PropertyExpressionInfo<TInfluxRow>( null, propertyInfo );
-                     if( expression.Type != typeof( string ) )
-                     {
-                        throw new InfluxException( string.Format( Errors.InvalidMeasurementNameType, propertyInfo.Name, type.Name ) );
+                        throw new InfluxException(string.Format(Errors.InvalidMeasurementNameType, propertyInfo.Name, type.Name));
                      }
 
                      influxMeasurement = expression;
                   }
+                  else if (columnAttribute != null)
+                  {
+                     var name = !string.IsNullOrWhiteSpace(columnAttribute.Name) ? columnAttribute.Name : propertyInfo.Name;
+
+                     var expression = new PropertyExpressionInfo<TInfluxRow>(name, propertyInfo);
+                     if (!ValidFieldTypes.Contains(expression.Type) && !expression.Type.GetTypeInfo().IsEnum)
+                     {
+                        throw new InfluxException(string.Format(Errors.InvalidFieldType, propertyInfo.Name, type.Name));
+                     }
+
+                     fields.Add(expression);
+                     all.Add(expression);
+                  }
+                  else if (fieldAttribute != null || notMappedAttribute == null)
+                  {
+                     if (fieldAttribute != null && string.IsNullOrEmpty(fieldAttribute.Name))
+                     {
+                        throw new InfluxException(string.Format(Errors.InvalidNameProperty, propertyInfo.Name, type.Name));
+                     }
+
+                     var name = fieldAttribute?.Name ?? propertyInfo.Name;
+
+                     var expression = new PropertyExpressionInfo<TInfluxRow>(name, propertyInfo);
+                     if (!ValidFieldTypes.Contains(expression.Type) && !expression.Type.GetTypeInfo().IsEnum)
+                     {
+                        throw new InfluxException(string.Format(Errors.InvalidFieldType, propertyInfo.Name, type.Name));
+                     }
+
+                     fields.Add(expression);
+                     all.Add(expression);
+                  }
                }
 
                bool isBasedOnInterface = false;
-               var genericTypeDefinitionOfImplementedInterface = GetGenericTypeDefinitionForImplementedInfluxInterface( type );
-               if( genericTypeDefinitionOfImplementedInterface != null )
+               var genericTypeDefinitionOfImplementedInterface = GetGenericTypeDefinitionForImplementedInfluxInterface(type);
+               if (genericTypeDefinitionOfImplementedInterface != null)
                {
-                  timestampType = genericTypeDefinitionOfImplementedInterface.GetGenericArguments()[ 0 ];
+                  timestampType = genericTypeDefinitionOfImplementedInterface.GetGenericArguments()[0];
                   isBasedOnInterface = true;
                }
-               else if( timestampType == null )
+               else if (timestampType == null)
                {
-                  timestampType = typeof( NullTimestamp );
+                  timestampType = typeof(NullTimestamp);
                }
 
-               cache = (InfluxRowTypeInfo<TInfluxRow>)typeof( InfluxRowTypeInfo<,> )
-                  .MakeGenericType( new[] { typeof( TInfluxRow ), timestampType } )
-                  .GetConstructors( BindingFlags.Instance | BindingFlags.NonPublic )[ 0 ]
-                  .Invoke( new object[] { isBasedOnInterface, timestamp, tags, fields, computed, all, influxMeasurement } );
-               TypeCache.Add( typeof( TInfluxRow ), cache );
+               cache = (InfluxRowTypeInfo<TInfluxRow>) typeof(InfluxRowTypeInfo<,>)
+                  .MakeGenericType(new[] { typeof(TInfluxRow), timestampType })
+                  .GetConstructors(BindingFlags.Instance | BindingFlags.NonPublic)[0]
+                  .Invoke(new object[] { isBasedOnInterface, timestamp, tags, fields, computed, all, influxMeasurement });
+               TypeCache.Add(typeof(TInfluxRow), cache);
             }
-            return (InfluxRowTypeInfo<TInfluxRow>)cache;
+            return (InfluxRowTypeInfo<TInfluxRow>) cache;
          }
       }
    }

--- a/src/Vibrant.InfluxDB.Client/Vibrant.InfluxDB.Client.csproj
+++ b/src/Vibrant.InfluxDB.Client/Vibrant.InfluxDB.Client.csproj
@@ -6,7 +6,7 @@
       <Copyright>Copyright (c) 2015-2018 MikaelGRA</Copyright>
       <AssemblyTitle>InfluxDB Client for .NET</AssemblyTitle>
       <Authors>MikaelGRA</Authors>
-      <TargetFrameworks>net45;netstandard1.3</TargetFrameworks>
+      <TargetFramework>netstandard20</TargetFramework>
       <AssemblyName>Vibrant.InfluxDB.Client</AssemblyName>
       <PackageId>Vibrant.InfluxDB.Client</PackageId>
       <PackageTags>influxdb;nosql;timeseries;data</PackageTags>
@@ -19,42 +19,31 @@
       <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
       <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
       <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
-      <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
       <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-      <Version>3.7.0</Version>
+      <Version>3.8.0</Version>
    </PropertyGroup>
-
-   <ItemGroup>
-      <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-   </ItemGroup>
-
-   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-      <Reference Include="System.Net" />
-      <Reference Include="System.Net.Http" />
-      <Reference Include="System.Runtime.Serialization" />
-      <Reference Include="System" />
-      <Reference Include="System.Core" />
-      <Reference Include="Microsoft.CSharp" />
-   </ItemGroup>
 
    <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
       <GenerateDocumentationFile>true</GenerateDocumentationFile>
    </PropertyGroup>
 
-   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
-      <PackageReference Include="Microsoft.CSharp" Version="4.0.1" />
-      <PackageReference Include="System.Collections" Version="4.0.11" />
-      <PackageReference Include="System.Collections.Concurrent" Version="4.0.12" />
-      <PackageReference Include="System.Net.Http" Version="4.1.1" />
-      <PackageReference Include="System.Net.Sockets" Version="4.1.0" />
-      <PackageReference Include="System.Runtime" Version="4.1.0" />
-      <PackageReference Include="System.Runtime.InteropServices" Version="4.1.0" />
-      <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.1.1" />
-      <PackageReference Include="System.Text.Encoding" Version="4.0.11" />
-      <PackageReference Include="System.Text.Encoding.Extensions" Version="4.0.11" />
-      <PackageReference Include="System.Linq.Queryable" Version="4.0.1" />
-      <PackageReference Include="System.Reflection.TypeExtensions" Version="4.1.0" />
-      <PackageReference Include="System.IO.Compression" Version="4.1.0" />
+   <ItemGroup>
+      <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
+      <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+      <PackageReference Include="NETStandard.Library" Version="2.0.3" />
+      <PackageReference Include="System.Collections" Version="4.3.0" />
+      <PackageReference Include="System.Collections.Concurrent" Version="4.3.0" />
+      <PackageReference Include="System.ComponentModel.Annotations" Version="4.5.0" />
+      <PackageReference Include="System.IO.Compression" Version="4.3.0" />
+      <PackageReference Include="System.Linq.Queryable" Version="4.3.0" />
+      <PackageReference Include="System.Net.Http" Version="4.3.3" />
+      <PackageReference Include="System.Net.Sockets" Version="4.3.0" />
+      <PackageReference Include="System.Reflection.TypeExtensions" Version="4.5.1" />
+      <PackageReference Include="System.Runtime" Version="4.3.0" />
+      <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />
+      <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
+      <PackageReference Include="System.Text.Encoding" Version="4.3.0" />
+      <PackageReference Include="System.Text.Encoding.Extensions" Version="4.3.0" />
    </ItemGroup>
 
 </Project>

--- a/test/Vibrant.InfluxDB.Client.ConsoleApp/ComputerInfo.cs
+++ b/test/Vibrant.InfluxDB.Client.ConsoleApp/ComputerInfo.cs
@@ -1,35 +1,49 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Vibrant.InfluxDB.Client.ConsoleApp
 {
+   [Table("computerInfo1")]
    public class ComputerInfo
+   {
+      [Key]
+      internal DateTime Timestamp { get; set; }
+
+      [Column("cpu")]
+      internal double? CPU { get; set; }
+
+      [Column("ram")]
+      internal long RAM { get; set; }
+
+      [NotMapped]
+      internal long PrivateData { get; set; }
+   }
+
+   public class ComputerInfoResult
    {
       [InfluxTimestamp]
       internal DateTime Timestamp { get; set; }
 
-      [InfluxTag( "host" )]
+      [InfluxTag("Host")]
       internal string Host { get; set; }
 
-      [InfluxTag( "region" )]
+      [InfluxTag("Region")]
       internal string Region { get; set; }
 
-      [InfluxField( "cpu" )]
+      [Column("cpu")]
       internal double? CPU { get; set; }
 
-      [InfluxField( "ram" )]
+      [InfluxField("ram")]
       internal long RAM { get; set; }
    }
 
    public class ComputerInfoMeta
    {
-      [InfluxField( "host" )]
+      [InfluxField("host")]
       internal string Host { get; set; }
 
-      [InfluxField( "region" )]
+      [InfluxField("region")]
       internal string Region { get; set; }
    }
 }

--- a/test/Vibrant.InfluxDB.Client.ConsoleApp/Program.cs
+++ b/test/Vibrant.InfluxDB.Client.ConsoleApp/Program.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -7,33 +6,76 @@ namespace Vibrant.InfluxDB.Client.ConsoleApp
 {
    public class Program
    {
-      public static void Main( string[] args )
-      {
-         var client = new InfluxClient( new Uri( "http://52.174.149.189:8086" ), "root", "root" );
+      private const string TestDatabase = "test-app";
+      private const string MeasurementName = "schema.computerInfo1";
+      private static readonly string[] TagNames = { "Host", "Region" };
+      private static readonly string[] Hosts = { "some-host", "some-other-host" };
+      private static readonly string[] Regions = { "west-eu", "north-eu", "west-us", "east-us", "asia" };
 
-         var from = new DateTime( 2010, 1, 1, 1, 1, 1, DateTimeKind.Utc );
-         var to = new DateTime( 2010, 1, 1, 1, 11, 1, DateTimeKind.Utc );
+      public static async Task Main(string[] args)
+      {
+         try
+         {
+            var client = new InfluxClient(new Uri("http://localhost:8086"));
+            var database = await client.ShowDatabasesAsync();
+
+            if ((await client.ShowDatabasesAsync()).Series.Single(s => s.Name == "databases").Rows.Any(d => d.Name == $"{TestDatabase}"))
+            {
+               await client.DropDatabaseAsync(TestDatabase);
+            }
+            await client.CreateDatabaseAsync(TestDatabase);
+
+            var from = DateTime.UtcNow;
+            var infos = CreateTypedRowsStartingAt(from, 1);
+
+            //await client.WriteAsync(TestDatabase, MeasurementName, infos, new InfluxWriteOptions
+            //{
+            //    DefaultTags =
+            //    {
+            //        { TagNames[0], Hosts[0] },
+            //        { TagNames[1], Regions[0] }
+            //    }
+            //});
+
+            await client.WriteAsync(TestDatabase, infos, new InfluxWriteOptions
+            {
+               DefaultTags =
+                    {
+                        { TagNames[0], Hosts[0] },
+                        { TagNames[1], Regions[0] }
+                    }
+            });
+
+            var records = await client.ReadAsync<ComputerInfoResult>(TestDatabase, $"select * from \"{MeasurementName}\"");
+         }
+         catch (Exception e)
+         {
+            Console.WriteLine(e);
+            throw;
+         }
+
+         Console.WriteLine("Done.");
+         Console.ReadKey();
       }
 
-      private static ComputerInfo[] CreateTypedRowsStartingAt( DateTime start, int rows )
+      private static ComputerInfo[] CreateTypedRowsStartingAt(DateTime start, int rows)
       {
          var rng = new Random();
-         var regions = new[] { "west-eu", "north-eu", "west-us", "east-us", "asia" };
-         var hosts = new[] { "some-host", "some-other-host" };
 
          var timestamp = start;
-         var infos = new ComputerInfo[ rows ];
-         for( int i = 0 ; i < rows ; i++ )
+         var infos = new ComputerInfo[rows];
+         for (int i = 0; i < rows; i++)
          {
-            long ram = rng.Next( int.MaxValue );
+            long ram = rng.Next(int.MaxValue);
             double cpu = rng.NextDouble();
-            string region = regions[ rng.Next( regions.Length ) ];
-            string host = hosts[ rng.Next( hosts.Length ) ];
+            //string region = Regions[rng.Next(Regions.Length)];
+            //string host = Hosts[rng.Next(Hosts.Length)];
 
-            var info = new ComputerInfo { Timestamp = timestamp, CPU = cpu, RAM = ram, Host = host, Region = region };
-            infos[ i ] = info;
+            //var info = new ComputerInfo { Timestamp = timestamp, CPU = cpu, RAM = ram, Host = host, Region = region };
+            var info = new ComputerInfo { Timestamp = timestamp, CPU = cpu, RAM = ram };
+            infos[i] = info;
 
-            timestamp = timestamp.AddSeconds( 1 );
+            timestamp = timestamp.AddSeconds(1);
          }
 
          return infos;

--- a/test/Vibrant.InfluxDB.Client.ConsoleApp/Vibrant.InfluxDB.Client.ConsoleApp.csproj
+++ b/test/Vibrant.InfluxDB.Client.ConsoleApp/Vibrant.InfluxDB.Client.ConsoleApp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFramework>net471</TargetFramework>
     <AssemblyName>Vibrant.InfluxDB.Client.ConsoleApp</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>Vibrant.InfluxDB.Client.ConsoleApp</PackageId>
@@ -13,10 +13,19 @@
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
+    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="NETStandard.Library" Version="2.0.3" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\src\Vibrant.InfluxDB.Client\Vibrant.InfluxDB.Client.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="System.ComponentModel.DataAnnotations" />
   </ItemGroup>
 
 </Project>

--- a/test/Vibrant.InfluxDB.Client.Tests/Vibrant.InfluxDB.Client.Tests.csproj
+++ b/test/Vibrant.InfluxDB.Client.Tests/Vibrant.InfluxDB.Client.Tests.csproj
@@ -1,11 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <AssemblyName>Vibrant.InfluxDB.Client.Tests</AssemblyName>
     <PackageId>Vibrant.InfluxDB.Client.Tests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <RuntimeFrameworkVersion>1.0.4</RuntimeFrameworkVersion>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
@@ -20,6 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="NETStandard.Library" Version="2.0.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
   </ItemGroup>


### PR DESCRIPTION
First off, very nice API - well done!

1) Reshaprer found several typos that we fixed.

2) Better existing support due to .NET standard 2.0
2.1) Because of .NET standard 2.0, we can now added support for existing objects. E.g. Added support .NET's `System.ComponentModel.DataAnnotations`: `TableAttribute`, `KeyAttribute`, `ColumnAttribute`, and `NotMappedAttribute`.
  Note: only the names are used any other property on these attributes are ignored.
2.2) Which required upgrading the projects to net standard 2.0

3) Added a proof-of-concept of defining only once the set of Tags that are associated with all the data point for a given Write call (called: DefaultTags). Example:

            await client.WriteAsync(TestDatabase, infos, new InfluxWriteOptions
            {
               DefaultTags =
                    {
                        { TagNames[0], Hosts[0] },
                        { TagNames[1], Regions[0] }
                    }
            });

This allow the a DTO to look like this:
```
   public class ComputerInfo
   {
      [Key]
      internal DateTime Timestamp { get; set; }

      [Column("cpu")]
      internal double? CPU { get; set; }

      [Column("ram")]
      internal long RAM { get; set; }

      [NotMapped]
      internal long PrivateData { get; set; }
   }
```
We called it a proof-of-concept because it was very easy to add to the option class but we think it really needs its own parameter on the various `WriteAsync` functions and it isn't bullet proof (i.e. distict tags aren't checked for).

We made these changes so that existing DTO would work correctly without having to add new attributes to them (which is some cases we don't own). Also, from a memory standpoint, added the same set of tags to 100K to 1Mil records is a huge waste of memory for us.
**Note**: breaking change - because we were able to move the tags to the write call, and because of the support of NotMapped all properties are now include that doesn't contain the NotMappedAttribute.

** You might want to add an explicit option to enable the set of changes.

- Also I had to changed the ConsoleApp to .NET 4.7.1 so that it could be debugged in VS.
- Sorry, my formatting doesn't match your formatting and I touched a few files by mistake. So you might want to cherry pick though these changes.

Cheers.